### PR TITLE
feat: implement dynamic component placement in EntryView.vue (#10)

### DIFF
--- a/src/components/CheckEdit.vue
+++ b/src/components/CheckEdit.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="check-edit">
+    <label class="check-edit-label">{{ name }}</label>
+    <input
+      type="checkbox"
+      class="check-edit-input"
+      :checked="value"
+      @change="$emit('update:value', $event.target.checked)"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'CheckEdit',
+
+  props: {
+    name:  { type: String, required: true },
+    value: { type: Boolean, default: false }
+  },
+
+  emits: ['update:value']
+}
+</script>
+
+<style scoped>
+.check-edit {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.check-edit-label {
+  min-width: 60px;
+  font-size: 13px;
+  color: #333;
+}
+
+.check-edit-input {
+  width: 16px;
+  height: 16px;
+}
+</style>

--- a/src/components/EntryView.vue
+++ b/src/components/EntryView.vue
@@ -5,9 +5,10 @@
       <div v-if="inputParamDefs.length > 0" class="entry-param">
         <div class="entry-param-title">Input</div>
         <div v-for="paramDef in inputParamDefs" :key="paramDef.name" class="param-row">
-          <SpinEdit
-            v-if="paramDef.ctrlType === 'integer_spinner'"
+          <component
+            :is="paramComponents[paramDef.ctrlType]"
             :name="paramDef.name"
+            :numberType="paramDef.ctrlType === 'real_spinner' ? 'real' : 'integer'"
             :min="paramDef.min"
             :max="paramDef.max"
             :step="paramDef.step"
@@ -27,12 +28,18 @@
 import { inject, computed, ref, watch } from 'vue'
 import { selectionState } from '../composables/useSelection'
 import SpinEdit from './SpinEdit.vue'
+import CheckEdit from './CheckEdit.vue'
 
 export default {
   name: 'EntryView',
-  components: { SpinEdit },
+  components: { SpinEdit, CheckEdit },
 
   setup() {
+    const paramComponents = {
+      integer_spinner: SpinEdit,
+      real_spinner:    SpinEdit,
+      checkbox:        CheckEdit,
+    }
     const entryManager = inject('entryManager')
     const entryParamManager = inject('entryParamManager')
     const entryDefinitionService = inject('entryDefinitionService')
@@ -70,7 +77,8 @@ export default {
       selectedEntry,
       inputParamDefs,
       localParams,
-      onParamChange
+      onParamChange,
+      paramComponents
     }
   }
 }


### PR DESCRIPTION
Implements dynamic component placement in EntryView.vue using `<component :is="...">` as requested in #10.

**Changes:**
- Replace `v-if` chain with `paramComponents[ctrlType]` lookup in EntryView.vue
- Add `paramComponents` map: integer_spinner/real_spinner → SpinEdit, checkbox → CheckEdit
- Add CheckEdit.vue for boolean checkbox params
- string_edit omitted as not needed at this time

Generated with [Claude Code](https://claude.ai/code)