### PR TITLE
feat: add BlockListView component and refactor SideArea

### DIFF
--- a/src/components/BlockListView.vue
+++ b/src/components/BlockListView.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="drag-items">
+    <div class="rect-item">
+      <div
+        class="rect-icon lime"
+        draggable="true"
+        @dragstart="onDragStartContainer"
+        @dragend="onDragEndContainer"
+      ></div>
+    </div>
+    <div
+      v-for="blockName in blockNames"
+      :key="blockName"
+      class="rect-item"
+    >
+      <div
+        class="rect-icon whitegray"
+        draggable="true"
+        @dragstart="onDragStartBlock"
+        @dragend="onDragEndBlock"
+      >{{ blockName }}</div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { inject, ref, onMounted } from 'vue';
+import { useDraggable } from '../composables/useDraggable';
+
+export default {
+  name: 'BlockListView',
+
+  setup() {
+    // Inject EntryDefinitionService
+    const entryDefinitionService = inject('entryDefinitionService');
+
+    // Reactive state for block names
+    const blockNames = ref([]);
+
+    // Get composable
+    const {
+      onDragStart: onDragStartBlock,
+      onDragEnd: onDragEndBlock,
+      setOnDragStartCallBack: setBlockDragStartCallback
+    } = useDraggable();
+
+    const {
+      onDragStart: onDragStartContainer,
+      onDragEnd: onDragEndContainer,
+      setOnDragStartCallBack: setContainerDragStartCallback
+    } = useDraggable();
+
+    // Set custom callbacks for drag start events
+    setBlockDragStartCallback((event) => {
+      event.dataTransfer.setData('entryType', 'block');
+      event.dataTransfer.setData('entryName', event.target.textContent);
+      event.dataTransfer.setData('sourceId', undefined);
+    });
+
+    setContainerDragStartCallback((event) => {
+      event.dataTransfer.setData('entryType', 'container');
+      event.dataTransfer.setData('entryName', 'Container');
+      event.dataTransfer.setData('sourceId', undefined);
+    });
+
+    // Load block definitions on mounted
+    onMounted(async () => {
+      await entryDefinitionService.loadBlockDefinitions();
+      blockNames.value = Object.keys(entryDefinitionService.blockDefinitions);
+      console.log('blockNames:', blockNames.value);
+    });
+
+    // Return values and methods to use in <template>
+    return {
+      blockNames,
+      onDragStartBlock,
+      onDragEndBlock,
+      onDragStartContainer,
+      onDragEndContainer
+    };
+  }
+}
+</script>
+
+<style scoped>
+.drag-items {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow-y: auto;
+}
+.rect-item {
+  margin-top: 32px;
+  width: 50px;
+  height: 50px;
+}
+.rect-icon {
+  width: 100%;
+  height: 100%;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  cursor: grab;
+}
+
+.rect-icon.whitegray {
+  background-color: #f0f0f0;
+  border: 1px solid #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 500;
+  color: #333;
+  box-sizing: border-box;
+}
+
+.rect-icon.lime {
+  background-color: #8eec9a;
+  border: 1px solid #7bc97b;
+}
+</style>

--- a/src/components/SideArea.vue
+++ b/src/components/SideArea.vue
@@ -1,27 +1,6 @@
 <template>
   <div class="side-area">
-    <div class="drag-items">
-      <div class="rect-item">
-        <div
-          class="rect-icon lime"
-          draggable="true"
-          @dragstart="onDragStartContainer"
-          @dragend="onDragEndContainer"
-        ></div>
-      </div>
-      <div
-        v-for="blockName in blockNames"
-        :key="blockName"
-        class="rect-item"
-      >
-        <div
-          class="rect-icon whitegray"
-          draggable="true"
-          @dragstart="onDragStartBlock"
-          @dragend="onDragEndBlock"
-        >{{ blockName }}</div>
-      </div>
-    </div>
+    <BlockListView />
     <div class="bottom-item">
       <EntryView />
     </div>
@@ -29,64 +8,14 @@
 </template>
 
 <script>
-import { inject, ref, onMounted } from 'vue';
-import { useDraggable } from '../composables/useDraggable';
+import BlockListView from './BlockListView.vue';
 import EntryView from './EntryView.vue';
 
 export default {
   name: 'SideArea',
   components: {
+    BlockListView,
     EntryView
-  },
-
-  setup() {
-    // Inject EntryDefinitionService
-    const entryDefinitionService = inject('entryDefinitionService');
-
-    // Reactive state for block names
-    const blockNames = ref([]);
-
-    // Get composable
-    const {
-      onDragStart: onDragStartBlock,
-      onDragEnd: onDragEndBlock,
-      setOnDragStartCallBack: setBlockDragStartCallback
-    } = useDraggable();
-
-    const {
-      onDragStart: onDragStartContainer,
-      onDragEnd: onDragEndContainer,
-      setOnDragStartCallBack: setContainerDragStartCallback
-    } = useDraggable();
-
-    // Set custom callbacks for drag start events
-    setBlockDragStartCallback((event) => {
-      event.dataTransfer.setData('entryType', 'block');
-      event.dataTransfer.setData('entryName', event.target.textContent);
-      event.dataTransfer.setData('sourceId', undefined);
-    });
-
-    setContainerDragStartCallback((event) => {
-      event.dataTransfer.setData('entryType', 'container');
-      event.dataTransfer.setData('entryName', 'Container');
-      event.dataTransfer.setData('sourceId', undefined);
-    });
-
-    // Load block definitions on mounted
-    onMounted(async () => {
-      await entryDefinitionService.loadBlockDefinitions();
-      blockNames.value = Object.keys(entryDefinitionService.blockDefinitions);
-      console.log('blockNames:', blockNames.value);
-    });
-
-    // Return values and methods to use in <template>
-    return {
-      blockNames,
-      onDragStartBlock,
-      onDragEndBlock,
-      onDragStartContainer,
-      onDragEndContainer
-    };
   }
 }
 </script>
@@ -99,45 +28,8 @@ export default {
   display: flex;
   flex-direction: column;
 }
-.drag-items {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  overflow-y: auto;
-}
-.rect-item {
-  margin-top: 32px;
-  width: 50px;
-  height: 50px;
-}
-.rect-icon {
-  width: 100%;
-  height: 100%;
-  border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  cursor: grab;
-}
-
-.rect-icon.whitegray {
-  background-color: #f0f0f0;
-  border: 1px solid #ccc;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 12px;
-  font-weight: 500;
-  color: #333;
-  box-sizing: border-box;
-}
-
-.rect-icon.lime {
-  background-color: #8eec9a;
-  border: 1px solid #7bc97b;
-}
 
 .bottom-item {
   border-top: 1px solid #ccc;
 }
-
 </style>


### PR DESCRIPTION
Extract drag-and-drop block list UI from SideArea into a new BlockListView component. SideArea now composes BlockListView (top) and EntryView (bottom).

Closes #12

Generated with [Claude Code](https://claude.ai/code)