### PR TITLE
feat: set 6:4 height ratio for BlockListView and EntryView in SideArea

### DIFF
--- a/src/components/BlockItem.vue
+++ b/src/components/BlockItem.vue
@@ -8,7 +8,7 @@
     @click.stop="onSelect"
   >
     <div class="block-content">
-    <div class="block-header">
+      <div class="block-header">
         <div class="entry-text">{{ entry.name }}</div>
         <div class="entry-button-group">
           <div v-if="isSelected" class="entry-button entry-button-play" @click.stop="onPlay"></div>

--- a/src/components/BlockListView.vue
+++ b/src/components/BlockListView.vue
@@ -90,7 +90,6 @@ export default {
   display: flex;
   flex-direction: column;
   align-items: center;
-  overflow-y: auto;
 }
 .rect-item {
   margin-top: 32px;

--- a/src/components/EntryView.vue
+++ b/src/components/EntryView.vue
@@ -86,14 +86,16 @@ export default {
 
 <style scoped>
 .entry-view {
-  width: 100%;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
   padding: 14px;
-  background: #fafafa;
 }
 
 .empty-content {
-  color: #999;
-  font-size: 13px;
+  font-size: 22px;
+  font-weight: bold;
+  color: #c0c0c0;
 }
 
 .entry-header {

--- a/src/components/SideArea.vue
+++ b/src/components/SideArea.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="side-area">
-    <div class="block-list-wrapper">
+    <div class="top-item">
       <BlockListView />
     </div>
     <div class="bottom-item">
@@ -31,16 +31,16 @@ export default {
   flex-direction: column;
 }
 
-.block-list-wrapper {
+.top-item {
   flex: 6;
   display: flex;
-  flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .bottom-item {
   flex: 4;
-  border-top: 1px solid #ccc;
+  display: flex;
   overflow-y: auto;
+  border-top: 1px solid #ccc;
 }
 </style>


### PR DESCRIPTION
Allocate vertical space in SideArea so that BlockListView occupies 60% and EntryView occupies 40% of the available height, maintaining this ratio even when EntryView contents are empty.

Closes #16

Generated with [Claude Code](https://claude.ai/code)