### PR TITLE
feat: display input parameters of executed entry in ExecutionLogView

### DIFF
--- a/src/components/ExecutionLogView.vue
+++ b/src/components/ExecutionLogView.vue
@@ -19,8 +19,8 @@
             <th class="col-start-time">Start Time</th>
             <th class="col-status">Status</th>
             <th class="col-name">Entry Name</th>
-            <th class="col-input-params">Input Parameters</th>
-            <th class="col-result">Result</th>
+            <th class="col-input-params">Input</th>
+            <th class="col-output-params">Output</th>
             <th class="col-error-msg">Error Message</th>
             <th class="col-exec-time">Exec. Time</th>
             <th class="col-id">ID</th>
@@ -39,7 +39,7 @@
               </td>             
               <td class="col-name">{{ item.data.entryName}}</td>
               <td class="col-input-params">{{ formatInputParams(item.data.inputParams) }}</td>
-              <td class="col-result">{{ formatResult(item.data.result) }}</td>
+              <td class="col-output-params">{{ formatOutputParams(item.data.outputParams) }}</td>
               <td class="col-error-msg">{{ item.data.result?.errorMessage }}</td>
               <td class="col-exec-time">{{ formatExecutionTime(item.data.execTime) }}ms</td>
               <td class="col-id">{{ item.data.entryId }}</td>
@@ -119,12 +119,12 @@ function formatInputParams(inputParams) {
 }
 
 /**
- * Format result properties
+ * Format result into output parameters for display
  * Displays properties other than success, errorMessage
  * @param {Object} result Execution result object
- * @returns {string} Formatted result data as key-value pairs
+ * @returns {string} Formatted output parameters as key-value pairs
  */
-function formatResult(result) {
+function formatOutputParams(result) {
   if (!result) return '';
   
   const excludedKeys = ['success', 'errorMessage'];
@@ -316,7 +316,7 @@ const transformedLogs = computed(() => {
   min-width: 160px;
 }
 
-.col-result {
+.col-output-params {
   min-width: 160px;
 }
 

--- a/src/services/entry_execution/EntryExecutionService.js
+++ b/src/services/entry_execution/EntryExecutionService.js
@@ -36,15 +36,15 @@ export default class EntryExecutionService {
   /**
    * Execute a block entry
    * @param {Block} block Block to execute
-   * @return {Promise<ScriptExecutionResult>} 
+   * @param {Object} inputParams Input parameters for the block (optional)
+   * @return {Promise<ScriptExecutionResult>}
    *         Execution result object conforming to ScriptExecutionResult type
    * @private
    */
-  async _executeBlock(block) {
+  async _executeBlock(block, inputParams = {}) {
     let result = {};
     try {
       // Execute script based on block name
-      const inputParams = this.entryParamManager ? this.entryParamManager.getInputParams(block.id) : {};
       result = await this.scriptExecutionService.executeScript(block.name, inputParams);
     } catch (error) {
       result.errorMessage = error.message;
@@ -104,13 +104,13 @@ export default class EntryExecutionService {
       // Generate execution ID
       const executionId = this._generateExecutionId(entry.id);
       // Log execution start if execution log service is available
+      const inputParams = this.entryParamManager ? this.entryParamManager.getInputParams(entry.id) : {};
       if (this.executionLogService) {
-        const inputParams = this.entryParamManager ? this.entryParamManager.getInputParams(entry.id) : {};
-        this.executionLogService.addLog(entry, executionId, traceId, inputParams);
+        this.executionLogService.addLog(entry, inputParams, executionId, traceId);
       }
       // Execute an entry
       if (entry.type === 'block') {
-        result = await this._executeBlock(entry);
+        result = await this._executeBlock(entry, inputParams);
       } else if (entry.type === 'container') {
         result = await this._executeContainer(entry, executionId);
       }

--- a/src/services/log/ExecutionLogService.js
+++ b/src/services/log/ExecutionLogService.js
@@ -126,7 +126,7 @@ export default class ExecutionLogService {
    * @param {Object} inputParams Input parameters of the entry at execution time (optional)
    * @returns {string} Execution ID that can be used later to update the log
    */
-  addLog(entry, executionId, parentExecutionId = null, inputParams = {}) {
+  addLog(entry, inputParams, executionId, parentExecutionId = null) {
     try {
       // Create execution log
       const execution = {


### PR DESCRIPTION
Closes #24

Displays the input parameters of each executed entry in the ExecutionLogView by capturing them at execution time via ExecutionLogService.

Generated with [Claude Code](https://claude.ai/code)