### PR TITLE
refactor: extract ContainerChildItem shared component

### DIFF
--- a/src/components/ContainerChildItem.vue
+++ b/src/components/ContainerChildItem.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="drop-area"
+      :class="{'is-active': dropAllowed}"
+      @drop="(event) => $emit('drop', event, 0)"
+      @dragover="(event) => $emit('dragover', event)"
+  />
+  <template v-for="(child, index) in children" :key="child.id">
+    <component
+      :is="child.type === 'block' ? 'BlockItem' : 'ContainerItem'"
+      :entry="child"
+      @remove="$emit('remove', $event)"
+    />
+    <div class="drop-area"
+        :class="{'is-active': dropAllowed}"
+        @drop="(event) => $emit('drop', event, index + 1)"
+        @dragover="(event) => $emit('dragover', event)"
+    />
+  </template>
+</template>
+
+<script>
+import { defineAsyncComponent } from 'vue'
+import BlockItem from './BlockItem.vue'
+
+export default {
+  name: 'ContainerChildItem',
+  components: {
+    BlockItem,
+    ContainerItem: defineAsyncComponent(() => import('./ContainerItem.vue'))
+  },
+  props: {
+    children: {
+      type: Array,
+      required: true
+    },
+    dropAllowed: {
+      type: Boolean,
+      required: true
+    }
+  },
+  emits: ['drop', 'dragover', 'remove']
+}
+</script>
+
+<style scoped>
+.drop-area {
+  height: 20px;
+  width: 100%;
+  border: 1px dashed transparent;
+  border-radius: 4px;
+  transition: all 0.3s ease;
+}
+
+.drop-area.is-active {
+  height: 20px;
+  border-color: #007bff;
+  background-color: rgba(0, 123, 255, 0.1);
+}
+</style>

--- a/src/components/ContainerChildItem.vue
+++ b/src/components/ContainerChildItem.vue
@@ -1,25 +1,27 @@
 <template>
   <div class="drop-area"
       :class="{'is-active': dropAllowed}"
-      @drop="(event) => $emit('drop', event, 0)"
-      @dragover="(event) => $emit('dragover', event)"
+      @drop="(event) => onDrop(event, 0)"
+      @dragover="onDragOver"
   />
   <template v-for="(child, index) in children" :key="child.id">
     <component
       :is="child.type === 'block' ? 'BlockItem' : 'ContainerItem'"
       :entry="child"
-      @remove="$emit('remove', $event)"
+      @remove="removeChild"
     />
     <div class="drop-area"
         :class="{'is-active': dropAllowed}"
-        @drop="(event) => $emit('drop', event, index + 1)"
-        @dragover="(event) => $emit('dragover', event)"
+        @drop="(event) => onDrop(event, index + 1)"
+        @dragover="onDragOver"
     />
   </template>
 </template>
 
 <script>
-import { defineAsyncComponent } from 'vue'
+import { defineAsyncComponent, computed } from 'vue'
+import { useDroppable } from '../composables/useDroppable'
+import { useEntryOperation } from '../composables/useEntryOperation'
 import BlockItem from './BlockItem.vue'
 
 export default {
@@ -29,16 +31,54 @@ export default {
     ContainerItem: defineAsyncComponent(() => import('./ContainerItem.vue'))
   },
   props: {
-    children: {
-      type: Array,
-      required: true
-    },
-    dropAllowed: {
-      type: Boolean,
+    entry: {
+      type: Object,
       required: true
     }
   },
-  emits: ['drop', 'dragover', 'remove']
+  setup(props) {
+    const {
+      isDroppable,
+      onDrop,
+      onDragOver,
+      setOnDropCallBack
+    } = useDroppable()
+    const {
+      addBlock,
+      addContainer,
+      removeEntry,
+      reorderEntry,
+      moveEntry
+    } = useEntryOperation()
+
+    const children = computed(() => props.entry.children)
+    const dropAllowed = isDroppable(props.entry.id)
+
+    setOnDropCallBack((event, index) => {
+      const entryType = event.dataTransfer.getData('entryType')
+      const entryName = event.dataTransfer.getData('entryName')
+      const entryId   = event.dataTransfer.getData('entryId')
+      const sourceId  = event.dataTransfer.getData('sourceId')
+
+      if (!entryId) {
+        if (entryType === 'block') {
+          addBlock(props.entry.id, entryName, index)
+        } else if (entryType === 'container') {
+          addContainer(props.entry.id, entryName, index)
+        }
+      } else if (!sourceId || sourceId === props.entry.id) {
+        reorderEntry(props.entry.id, entryId, index)
+      } else {
+        moveEntry(entryId, props.entry.id, index)
+      }
+    })
+
+    const removeChild = (id) => {
+      removeEntry(id)
+    }
+
+    return { children, dropAllowed, onDrop, onDragOver, removeChild }
+  }
 }
 </script>
 

--- a/src/components/ContainerItem.vue
+++ b/src/components/ContainerItem.vue
@@ -17,26 +17,13 @@
         <EntryParamsItem v-if="isSelected" :entry-id="entry.id" />
       </div>
       <div class="container-children">
-        <!-- First drop area (always displayed) -->
-        <div class="drop-area" 
-            :class="{'is-active': dropAllowed}"
-            @drop="(event) => onDrop(event, 0)"
-            @dragover="onDragOver"
+        <ContainerChildItem
+          :children="children"
+          :drop-allowed="dropAllowed"
+          @drop="onDrop"
+          @dragover="onDragOver"
+          @remove="removeChild"
         />
-        <!-- Each entry (block or container) and its drop area below -->
-        <template v-for="(child, index) in children" :key="child.id">
-          <!-- Switch component based on entry type -->
-          <component 
-            :is="child.type === 'block' ? 'BlockItem' : 'ContainerItem'"
-            :entry="child"
-            @remove="removeChild"
-          />
-          <div class="drop-area"
-              :class="{'is-active': dropAllowed}"
-              @drop="(event) => onDrop(event, index + 1)"
-              @dragover="onDragOver"
-          />
-        </template>
       </div>
     </div>
   </div>
@@ -49,14 +36,14 @@ import { useDroppable } from '../composables/useDroppable'
 import { useEntryOperation } from '../composables/useEntryOperation'
 import { useEntryExecution } from '../composables/useEntryExecution'
 import { entryState } from '../composables/useEntryState'
-import BlockItem from './BlockItem.vue'
 import EntryParamsItem from './EntryParamsItem.vue'
+import ContainerChildItem from './ContainerChildItem.vue'
 
 export default {
   name: 'ContainerItem',
   components: {
-    BlockItem,
-    EntryParamsItem
+    EntryParamsItem,
+    ContainerChildItem
   },
   props: {
     entry: {
@@ -288,19 +275,5 @@ export default {
   width: 100%;
   display: flex;
   flex-direction: column;
-}
-
-.drop-area {
-  height: 20px;
-  width: 100%;
-  border: 1px dashed transparent;
-  border-radius: 4px;
-  transition: all 0.3s ease;
-}
-
-.drop-area.is-active {
-  height: 20px;
-  border-color: #007bff;
-  background-color: rgba(0, 123, 255, 0.1);
 }
 </style>

--- a/src/components/ContainerItem.vue
+++ b/src/components/ContainerItem.vue
@@ -18,11 +18,7 @@
       </div>
       <div class="container-children">
         <ContainerChildItem
-          :children="children"
-          :drop-allowed="dropAllowed"
-          @drop="onDrop"
-          @dragover="onDragOver"
-          @remove="removeChild"
+          :entry="entry"
         />
       </div>
     </div>
@@ -30,10 +26,8 @@
 </template>
 
 <script>
-import { computed } from 'vue'
-import { useDraggable } from '../composables/useDraggable'
-import { useDroppable } from '../composables/useDroppable'
 import { useEntryOperation } from '../composables/useEntryOperation'
+import { useDraggable } from '../composables/useDraggable'
 import { useEntryExecution } from '../composables/useEntryExecution'
 import { entryState } from '../composables/useEntryState'
 import EntryParamsItem from './EntryParamsItem.vue'
@@ -62,17 +56,6 @@ export default {
       setOnDragStartCallBack
     } = useDraggable()
     const {
-      isDroppable,
-      onDragOver,
-      onDrop,
-      setOnDropCallBack,
-    } = useDroppable()
-    const {
-      addBlock,
-      addContainer,
-      removeEntry,
-      reorderEntry,
-      moveEntry,
       getAllDescendantIds,
       getParentId,
     } = useEntryOperation()
@@ -102,34 +85,6 @@ export default {
       event.stopPropagation()
     })
 
-    // Set custom callbacks for drop event
-    setOnDropCallBack((event, index) => {
-      // Get data directly from event.dataTransfer
-      const entryType = event.dataTransfer.getData('entryType')
-      const entryName = event.dataTransfer.getData('entryName')
-      const entryId = event.dataTransfer.getData('entryId')
-      const sourceId = event.dataTransfer.getData('sourceId')
-
-      if (!entryId) {
-        // Create and insert a new element
-        if (index !== null) {
-          if (entryType === 'block') {
-            addBlock(props.entry.id, entryName, index)
-          } else if (entryType === 'container') {
-            addContainer(props.entry.id, entryName, index)
-          }
-        }
-      } else {
-        if (sourceId === props.entry.id) {
-          // Reorder within the same container
-          reorderEntry(props.entry.id, entryId, index)
-        } else {
-          // Drag & drop from another container
-          moveEntry(entryId, props.entry.id, index)
-        }
-      }
-    })
-
     /**
      * Process when the play button is clicked
      */
@@ -156,20 +111,6 @@ export default {
       emit('remove', props.entry.id)
     }
 
-    /**
-     * Remove a child entry
-     * @param {string} id - ID of the child to remove
-     */
-    const removeChild = (id) => {
-      removeEntry(id)
-    }
-
-    // Array of children
-    const children = computed(() => props.entry.children)
-
-    // For determining whether to allow the drop
-    const dropAllowed = isDroppable(props.entry.id)
-    
     // Return values and methods to use in <template>
     return {
       isDragging,
@@ -177,13 +118,8 @@ export default {
       onDragStart,
       onDragEnd,
       onSelect,
-      onDragOver,
-      onDrop,
       onPlay,
       onRemove,
-      removeChild,
-      children,
-      dropAllowed
     }
   }
 }

--- a/src/components/MainArea.vue
+++ b/src/components/MainArea.vue
@@ -14,11 +14,7 @@
     </div>
     <div class="entry-panel" ref="entryPanelRef">
       <ContainerChildItem
-        :children="children"
-        :drop-allowed="dropAllowed"
-        @drop="onDrop"
-        @dragover="onDragOver"
-        @remove="removeChild"
+        :entry="mainContainer"
       />
     </div>
     <div class="connection-panel">
@@ -27,8 +23,7 @@
 </template>
 
 <script>
-import { ref, computed } from 'vue'
-import { useDroppable } from '../composables/useDroppable'
+import { ref } from 'vue'
 import { useEntryOperation } from '../composables/useEntryOperation'
 import { entryState } from '../composables/useEntryState'
 import { useEntryRect } from '../composables/useEntryRect'
@@ -41,65 +36,10 @@ export default {
   },
   
   setup() {
-    // Get composable
-    const {
-      isDroppable,
-      onDragOver,
-      onDrop,
-      setOnDropCallBack
-    } = useDroppable()
-    const { 
-      addBlock,
-      addContainer,
-      removeEntry,
-      reorderEntry,
-      moveEntry
-    } = useEntryOperation()
+    const { addContainer } = useEntryOperation()
 
     // Create a top-level container & register it in EntryManager
     const mainContainer = addContainer(null, 'main-area', 0)
-    
-    /**
-     * Remove a child entry
-     * @param {string} id - ID of the child to remove
-     */
-    const removeChild = (id) => {
-      removeEntry(id)
-    }
-    
-    // Set custom callbacks for drop event
-    setOnDropCallBack((event, index) => {
-      // Get data directly from event.dataTransfer
-      const entryType = event.dataTransfer.getData('entryType')
-      const entryName = event.dataTransfer.getData('entryName')
-      const entryId = event.dataTransfer.getData('entryId')
-      const sourceId = event.dataTransfer.getData('sourceId')
-      
-      if (!entryId) {
-        // Create and insert a new element
-        if (index !== null) {
-          if (entryType === 'block') {
-            addBlock(mainContainer.id, entryName, index)
-          } else if (entryType === 'container') {
-            addContainer(mainContainer.id, entryName, index)
-          }
-        }
-      } else {
-        if (!sourceId || sourceId === mainContainer.id) {
-          // Reorder within MainArea
-          reorderEntry(mainContainer.id, entryId, index)
-        } else {
-          // Drag & drop from a container
-          moveEntry(entryId, mainContainer.id, index)
-        }
-      }
-    })
-
-    // Array of children
-    const children = computed(() => mainContainer.children)
-
-    // For determining whether to allow the drop
-    const dropAllowed = isDroppable(mainContainer.id)
 
     // Template ref for the entry panel
     const entryPanelRef = ref(null)
@@ -107,11 +47,7 @@ export default {
 
     // Return values and methods to use in <template>
     return {
-      onDragOver,
-      onDrop,
-      removeChild,
-      children,
-      dropAllowed,
+      mainContainer,
       entryState,
       entryPanelRef,
       entryLayoutMap

--- a/src/components/MainArea.vue
+++ b/src/components/MainArea.vue
@@ -13,26 +13,13 @@
       />
     </div>
     <div class="entry-panel" ref="entryPanelRef">
-      <!-- First drop area (always displayed) -->
-      <div class="drop-area"
-          :class="{'is-active': dropAllowed}"
-          @drop="(event) => onDrop(event, 0)"
-          @dragover="onDragOver"
+      <ContainerChildItem
+        :children="children"
+        :drop-allowed="dropAllowed"
+        @drop="onDrop"
+        @dragover="onDragOver"
+        @remove="removeChild"
       />
-      <!-- Each entry (block or container) and its drop area below -->
-      <template v-for="(entry, index) in children" :key="entry.id">
-        <!-- Switch component based on entry type -->
-        <component
-          :is="entry.type === 'block' ? 'BlockItem' : 'ContainerItem'"
-          :entry="entry"
-          @remove="removeChild"
-        />
-        <div class="drop-area"
-            :class="{'is-active': dropAllowed}"
-            @drop="(event) => onDrop(event, index + 1)"
-            @dragover="onDragOver"
-        />
-      </template>
     </div>
     <div class="connection-panel">
     </div>
@@ -45,14 +32,12 @@ import { useDroppable } from '../composables/useDroppable'
 import { useEntryOperation } from '../composables/useEntryOperation'
 import { entryState } from '../composables/useEntryState'
 import { useEntryRect } from '../composables/useEntryRect'
-import BlockItem from './BlockItem.vue'
-import ContainerItem from './ContainerItem.vue'
+import ContainerChildItem from './ContainerChildItem.vue'
 
 export default {
   name: 'MainArea',
   components: {
-    BlockItem,
-    ContainerItem
+    ContainerChildItem
   },
   
   setup() {
@@ -179,19 +164,5 @@ export default {
   height: 1px;
   background-color: #ccc;
   pointer-events: none;
-}
-
-.drop-area {
-  height: 20px;
-  width: 100%;
-  border: 1px dashed transparent;
-  border-radius: 4px;
-  transition: all 0.3s ease;
-}
-
-.drop-area.is-active {
-  height: 20px;
-  border-color: #007bff;
-  background-color: rgba(0, 123, 255, 0.1);
 }
 </style>


### PR DESCRIPTION
Extract the shared drop area + child entry rendering template into a new `ContainerChildItem` component, used by both `ContainerItem` and `MainArea`.

Closes #51

Generated with [Claude Code](https://claude.ai/code)