### PR TITLE
feat: add ConnectionItem.vue component

### DIFF
--- a/src/components/ConnectionItem.vue
+++ b/src/components/ConnectionItem.vue
@@ -1,0 +1,56 @@
+<template>
+  <path
+    v-if="pathD"
+    :d="pathD"
+    class="connection-path"
+  />
+</template>
+
+<script>
+import { computed, inject } from 'vue'
+
+export default {
+  name: 'ConnectionItem',
+
+  props: {
+    output: {
+      type: Object,
+      required: true
+    },
+    input: {
+      type: Object,
+      required: true
+    }
+  },
+
+  setup(props) {
+    const entryLayoutManager = inject('entryLayoutManager')
+
+    const pathD = computed(() => {
+      const layoutMap = entryLayoutManager.layoutMap
+      const outLayout = layoutMap.get(props.output.entryId)
+      const inLayout = layoutMap.get(props.input.entryId)
+      if (!outLayout || !inLayout) return null
+
+      const y1 = outLayout.y + outLayout.height / 2
+      const y2 = inLayout.y + inLayout.height / 2
+      const x1 = 0
+      const x2 = 160
+      const cx = (x1 + x2) / 2
+
+      return `M ${x1} ${y1} C ${cx} ${y1}, ${cx} ${y2}, ${x2} ${y2}`
+    })
+
+    return { pathD }
+  }
+}
+</script>
+
+<style scoped>
+.connection-path {
+  fill: none;
+  stroke: #5a9fd4;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+</style>

--- a/src/components/ConnectionView.vue
+++ b/src/components/ConnectionView.vue
@@ -5,48 +5,29 @@
     width="100%"
     height="100%"
   >
-    <path
-      v-for="conn in connectionPaths"
+    <ConnectionItem
+      v-for="conn in connections"
       :key="conn.id"
-      :d="conn.d"
-      class="connection-path"
+      :output="conn.output"
+      :input="conn.input"
     />
   </svg>
 </template>
 
 <script>
 import { computed, inject } from 'vue'
+import ConnectionItem from './ConnectionItem.vue'
 
 export default {
   name: 'ConnectionView',
+  components: { ConnectionItem },
 
   setup() {
     const entryConnectionManager = inject('entryConnectionManager')
-    const entryLayoutManager = inject('entryLayoutManager')
 
-    const connectionPaths = computed(() => {
-      const connections = entryConnectionManager.getConnections()
-      const layoutMap = entryLayoutManager.layoutMap
+    const connections = computed(() => entryConnectionManager.getConnections())
 
-      return connections.flatMap(conn => {
-        const outLayout = layoutMap.get(conn.output.entryId)
-        const inLayout = layoutMap.get(conn.input.entryId)
-        if (!outLayout || !inLayout) return []
-
-        const y1 = outLayout.y + outLayout.height / 2
-        const y2 = inLayout.y + inLayout.height / 2
-        const x1 = 0
-        const x2 = 160
-        const cx = (x1 + x2) / 2
-
-        return [{
-          id: conn.id,
-          d: `M ${x1} ${y1} C ${cx} ${y1}, ${cx} ${y2}, ${x2} ${y2}`,
-        }]
-      })
-    })
-
-    return { connectionPaths }
+    return { connections }
   }
 }
 </script>
@@ -55,12 +36,5 @@ export default {
 .connection-view {
   display: block;
   overflow: visible;
-}
-
-.connection-path {
-  fill: none;
-  stroke: #5a9fd4;
-  stroke-width: 2;
-  stroke-linecap: round;
 }
 </style>


### PR DESCRIPTION
Add `ConnectionItem.vue`, a new component that renders a single SVG connection line.

- Accepts `output` and `input` endpoint props from `ConnectionView`
- Injects `entryLayoutManager` to compute the cubic Bézier path
- `ConnectionView` is updated to use `ConnectionItem` instead of rendering paths inline

Closes #65

Generated with [Claude Code](https://claude.ai/code)